### PR TITLE
fix: Fix typo in the license modal

### DIFF
--- a/components/ModelList.tsx
+++ b/components/ModelList.tsx
@@ -141,7 +141,7 @@ const EachModel = ({ model }: { model: ModelData }) => {
             />
             <LicenseRow
               style={model.license.personalNonCommercialUse ? 'ok' : 'ng'}
-              title="┗  個人の非営利目的の活動（同人誌活動）のみ"
+              title="┗  個人の非営利目的の活動（同人活動等）のみ"
             />
             <LicenseRow style={model.license.modification ? 'ok' : 'ng'} title="改変" />
             <LicenseRow style={model.license.redistribution ? 'ok' : 'ng'} title="再配布" />


### PR DESCRIPTION
Example内で表示されるモデルの利用条件で「個人の非営利目的の活動（同人活動等）のみ」となるべきところが「個人の非営利目的の活動（同人誌活動）のみ」となってしまっていたので、これを修正しました。
