### PR TITLE
fix: keep VRoid Hub OAuth access tokens server-side

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 CLIENT_ID=hogehoge123456789
 CLIENT_SECRET=hogehogesecret
-NEXT_PUBLIC_NEXTAUTH_SECRET=hogehoge
+NEXTAUTH_SECRET=hogehoge
 NEXTAUTH_URL=https://example.com
 NEXT_PUBLIC_VROID_HUB_URL=https://hub.vroid.com

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ git clone git@github.com:pixiv/VRoidHub-API-Example.git
 ```
 CLIENT_ID= アプリケーションページから閲覧できるアプリケーションIDの値を入力してください
 CLIENT_SECRET= アプリケーションページから閲覧できるシークレットの値を入力してください
-NEXT_PUBLIC_NEXTAUTH_SECRET= openssl rand -base64 32 コマンドで生成したシークレット値を入力してください
+NEXTAUTH_SECRET= openssl rand -base64 32 コマンドで生成したシークレット値を入力してください
 NEXTAUTH_URL= ExampleをホストしているURLのroot URLを入力してください
 NEXT_PUBLIC_VROID_HUB_URL= https://hub.vroid.com と入力してください
 ```

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,14 @@
+import type { NextApiRequest } from 'next';
+import { getToken } from 'next-auth/jwt';
+
+/**
+ * Gets the OAuth access token from the server-side NextAuth JWT.
+ */
+export async function getAccessToken(req: NextApiRequest): Promise<string | null> {
+  const token = await getToken({
+    req,
+    secret: process.env.NEXTAUTH_SECRET,
+  });
+
+  return typeof token?.accessToken === 'string' ? token.accessToken : null;
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -5,9 +5,14 @@ import { getToken } from 'next-auth/jwt';
  * Gets the OAuth access token from the server-side NextAuth JWT.
  */
 export async function getAccessToken(req: NextApiRequest): Promise<string | null> {
+  const secret = process.env.NEXTAUTH_SECRET;
+  if (!secret) {
+    throw new Error('NEXTAUTH_SECRET is not set');
+  }
+
   const token = await getToken({
     req,
-    secret: process.env.NEXTAUTH_SECRET,
+    secret,
   });
 
   return typeof token?.accessToken === 'string' ? token.accessToken : null;

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -1,6 +1,7 @@
 import NextAuth from 'next-auth';
 
 export default NextAuth({
+  secret: process.env.NEXTAUTH_SECRET,
   providers: [
     {
       id: 'vroid',
@@ -66,11 +67,6 @@ export default NextAuth({
       }
 
       return token;
-    },
-
-    async session({ session, token }) {
-      session.accessToken = token.accessToken;
-      return session;
     },
   },
 });

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -1,7 +1,12 @@
 import NextAuth from 'next-auth';
 
+const nextAuthSecret = process.env.NEXTAUTH_SECRET;
+if (!nextAuthSecret) {
+  throw new Error('NEXTAUTH_SECRET is not set');
+}
+
 export default NextAuth({
-  secret: process.env.NEXTAUTH_SECRET,
+  secret: nextAuthSecret,
   providers: [
     {
       id: 'vroid',

--- a/pages/api/vroid/models/account.ts
+++ b/pages/api/vroid/models/account.ts
@@ -1,7 +1,7 @@
-import { getSession } from 'next-auth/react';
 import type { CharacterModelCollectionResponse, CharacterModelSerializer } from '@/types/Response';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { vroidHubApi } from '@/lib/vroid-hub-api';
+import { getAccessToken } from '@/lib/auth';
 
 type Query = {
   max_id: string;
@@ -11,7 +11,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const query = req.query as Query;
 
   // oauthのアクセストークンを取得
-  const token: string = (await getSession({ req }))?.accessToken as string;
+  const token = await getAccessToken(req);
 
   if (!token) {
     // トークンを保持していなければ401

--- a/pages/api/vroid/models/hearts.ts
+++ b/pages/api/vroid/models/hearts.ts
@@ -1,7 +1,7 @@
-import { getSession } from 'next-auth/react';
 import { CharacterModelCollectionResponse, CharacterModelSerializer } from '../../../../types/Response';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { vroidHubApi } from '@/lib/vroid-hub-api';
+import { getAccessToken } from '@/lib/auth';
 
 type Query = {
   max_id: string;
@@ -11,7 +11,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const query = req.query as Query;
 
   // oauthのアクセストークンを取得
-  const token: string = (await getSession({ req }))?.accessToken as string;
+  const token = await getAccessToken(req);
 
   if (!token) {
     // トークンを保持していなければ401

--- a/pages/api/vroid/models/staff_picks.ts
+++ b/pages/api/vroid/models/staff_picks.ts
@@ -1,7 +1,7 @@
 import type { CharacterModelSerializer, HeartCollectionResponse } from '@/types/Response';
-import { getSession } from 'next-auth/react';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { vroidHubApi } from '@/lib/vroid-hub-api';
+import { getAccessToken } from '@/lib/auth';
 
 type Query = {
   max_id: string;
@@ -11,7 +11,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const query = req.query as Query;
 
   // oauthのアクセストークンを取得
-  const token: string = (await getSession({ req }))?.accessToken as string;
+  const token = await getAccessToken(req);
 
   if (!token) {
     // トークンを保持していなければ401

--- a/pages/api/vroid/vrm.ts
+++ b/pages/api/vroid/vrm.ts
@@ -1,6 +1,6 @@
-import { getSession } from 'next-auth/react';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { fetchVRMModel } from '../../../lib/vroid-hub-api';
+import { getAccessToken } from '../../../lib/auth';
 
 type Query = {
   id?: string;
@@ -14,7 +14,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(400).json({ message: 'please specify the id.' });
   }
 
-  const token = (await getSession({ req }))?.accessToken as string | undefined;
+  const token = await getAccessToken(req);
 
   // tokenが取れなかった時は401
   if (!token) {

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -3,7 +3,7 @@ declare global {
     interface ProcessEnv {
       CLIENT_ID: string;
       CLIENT_SECRET: string;
-      NEXT_PUBLIC_NEXTAUTH_SECRET: string;
+      NEXTAUTH_SECRET: string;
       NEXTAUTH_URL: string;
       NEXT_PUBLIC_VROID_HUB_URL: string;
     }

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -3,14 +3,9 @@
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import NextAuth from 'next-auth';
-import { DefaultSession } from 'next-auth';
 import { JWT } from 'next-auth/jwt';
 
 declare module 'next-auth' {
-  interface Session {
-    accessToken?: string;
-  }
-
   interface OAuthConfig {
     scope?: string;
     params: {


### PR DESCRIPTION
### USER ACTIONS REQUIRED:

- `.env` の `NEXT_PUBLIC_NEXTAUTH_SECRET` を `NEXTAUTH_SECRET` に変更してください。
- secret変更後は既存セッションが無効になり、再ログインが必要になる場合があります。

### 概要

VRoid HubのOAuthアクセストークンがNextAuthの暗号化JWT cookieから`/api/auth/session`のレスポンスへコピーされ、ブラウザ上のJavaScriptから取得可能な状態でした。 トークン漏洩時の影響を抑え、アクセストークンをサーバー側だけで扱えるようにします。

- NextAuthのセッション情報にVRoid HubのOAuthアクセストークンを含めないように変更
- APIルートが、クライアント向けのセッションレスポンスではなく暗号化JWT cookieからアクセストークンを取得するように変更
- `accessToken`をクライアント向けのSession型から削除
- NextAuthのsecret設定を公開環境変数`NEXT_PUBLIC_NEXTAUTH_SECRET`からサーバー専用の`NEXTAUTH_SECRET`へ変更

NextAuthの暗号化JWT cookieは引き続きセッション情報の保存に使用しますが、`/api/auth/session`のレスポンスにはVRoid HubのOAuthアクセストークンを含めません。

Ref: https://next-auth.js.org/configuration/options